### PR TITLE
fix errant and unneeded reference to args

### DIFF
--- a/pupepat/main.py
+++ b/pupepat/main.py
@@ -94,7 +94,7 @@ def handle_config(output_dir, config_filename):
         with open(os.path.join(output_dir, config_dump_filename), 'w') as output_file:
             yaml.dump(config, output_file, default_flow_style=False)
     except PermissionError as e:
-        logger.error('Check write permissions of output directory: {d}\n{err}'.format(d=args.output_dir, err=e))
+        logger.error('Check write permissions of output directory: {d}\n{err}'.format(d=output_dir, err=e))
         sys.exit(1)
 
 


### PR DESCRIPTION
tested locally and works as expected:
```
[llindstrom@llindstrom-linux.lco.gtn min-test]$ ~/bin/pupe-pat-min-test.sh
2018-09-17 18:13:11.934    ERROR:            main: Check write permissions of output directory: /output
[Errno 13] Permission denied: '/output/pupe-pat-default-config.yaml'
```