### PR TITLE
add an M1 offset to the donut plot

### DIFF
--- a/pupepat/ellipse.py
+++ b/pupepat/ellipse.py
@@ -77,7 +77,7 @@ def calculate_donut_offset(inner_coordinate, outer_coordinate, sbig=False):
     (https://lcogt.slack.com/archives/C8V95PF9T/p1519653167000491)
 
     :param inner_coordinate: inner coordinate (x or y) in pixels
-    :param outer_coordinate: outer coordinate (x or y) in pixels 
+    :param outer_coordinate: outer coordinate (x or y) in pixels
     :param sbig: set to True if using a kb camera, and you want the offset to be in mm of M1 offset
     :return: offset
     """

--- a/pupepat/ellipse.py
+++ b/pupepat/ellipse.py
@@ -67,3 +67,24 @@ def generate_ellipse(x0, y0, a, b, theta):
     np.append(x, x[0])
     np.append(y, y[0])
     return x, y
+
+
+def calculate_donut_offset(inner_coordinate, outer_coordinate, sbig=False):
+    """
+    Calculate the offset of the inner coordinate from the outer coordinate.
+    Will return the offset in pixels unless sbig is set to True, in which case it will return the offset in mm of M1
+    offset based on calculations by Patrick Conway using zemax in Feb. 2018.
+    (https://lcogt.slack.com/archives/C8V95PF9T/p1519653167000491)
+
+    :param inner_coordinate: inner coordinate (x or y) in pixels
+    :param outer_coordinate: outer coordinate (x or y) in pixels 
+    :param sbig: set to True if using a kb camera, and you want the offset to be in mm of M1 offset
+    :return: offset
+    """
+
+    pixel_to_m1_mm = 9.679  # mm of M1 offset per pixel for an sbig on a 1m telescope
+
+    offset = inner_coordinate - outer_coordinate  # pixels
+    if sbig:
+        offset /= pixel_to_m1_mm  # mm of M1 offset
+    return offset

--- a/pupepat/ellipse.py
+++ b/pupepat/ellipse.py
@@ -76,6 +76,8 @@ def calculate_donut_offset(inner_coordinate, outer_coordinate, sbig=False):
     offset based on calculations by Patrick Conway using zemax in Feb. 2018.
     (https://lcogt.slack.com/archives/C8V95PF9T/p1519653167000491)
 
+    Warning from Brook: The signs of the offsets assume the camera was installed with the correct orientation.
+
     :param inner_coordinate: inner coordinate (x or y) in pixels
     :param outer_coordinate: outer coordinate (x or y) in pixels
     :param sbig: set to True if using a kb camera, and you want the offset to be in mm of M1 offset

--- a/pupepat/plot.py
+++ b/pupepat/plot.py
@@ -45,10 +45,8 @@ def plot_best_fit_ellipse(output_filename, data_cutout, best_fit_model, header):
                 'Outer: {x: 0.3f}, {y: 0.3f}'.format(x=best_fit_model.x0_outer, y=best_fit_model.y0_outer),
                 color='white')
     pyplot.text(data_cutout.shape[1] * 0.01, data_cutout.shape[0] * 0.88,
-                'I-O Offset (pix): {x: 0.3f}, {y: 0.3f}'.format(x=calculate_donut_offset(best_fit_model.x0_inner,
-                                                                                         best_fit_model.x0_outer),
-                                                                y=calculate_donut_offset(best_fit_model.y0_inner,
-                                                                                         best_fit_model.y0_outer)),
+                'I-O Offset (pix): {x: 0.3f}, {y: 0.3f}'.format(x=best_fit_model.x0_inner - best_fit_model.x0_outer,
+                                                                y=best_fit_model.y0_inner - best_fit_model.y0_outer),
                 color='white')
     pyplot.text(data_cutout.shape[1] * 0.6, data_cutout.shape[0] * 0.95,
                 'M2 Pitch: {pitch: 0.3f}"'.format(pitch=header['M2PITCH']), color='white')

--- a/pupepat/plot.py
+++ b/pupepat/plot.py
@@ -44,30 +44,29 @@ def plot_best_fit_ellipse(output_filename, data_cutout, best_fit_model, header):
     pyplot.text(data_cutout.shape[1] * 0.01, data_cutout.shape[0] * 0.915,
                 'Outer: {x: 0.3f}, {y: 0.3f}'.format(x=best_fit_model.x0_outer, y=best_fit_model.y0_outer),
                 color='white')
-
-    # If using an sbig camera on a 1m, calculate the M1 offset, otherwise give offset in pixels
-    if 'kb' in header['INSTRUME'].lower() and '1m0' in header['TELID'].lower():
-        pyplot.text(data_cutout.shape[1] * 0.01, data_cutout.shape[0] * 0.88,
-                    'M1 Offset (mm): {x: 0.3f}, {y: 0.3f}'.format(x=calculate_donut_offset(best_fit_model.x0_inner,
-                                                                                           best_fit_model.x0_outer,
-                                                                                           sbig=True),
-                                                                  y=calculate_donut_offset(best_fit_model.y0_inner,
-                                                                                           best_fit_model.y0_outer,
-                                                                                           sbig=True)),
-                    color='white')
-    else:
-        pyplot.text(data_cutout.shape[1] * 0.01, data_cutout.shape[0] * 0.88,
-                    'I-O Offset (pix): {x: 0.3f}, {y: 0.3f}'.format(x=calculate_donut_offset(best_fit_model.x0_inner,
-                                                                                             best_fit_model.x0_outer),
-                                                                    y=calculate_donut_offset(best_fit_model.y0_inner,
-                                                                                             best_fit_model.y0_outer)),
-                    color='white')
+    pyplot.text(data_cutout.shape[1] * 0.01, data_cutout.shape[0] * 0.88,
+                'I-O Offset (pix): {x: 0.3f}, {y: 0.3f}'.format(x=calculate_donut_offset(best_fit_model.x0_inner,
+                                                                                         best_fit_model.x0_outer),
+                                                                y=calculate_donut_offset(best_fit_model.y0_inner,
+                                                                                         best_fit_model.y0_outer)),
+                color='white')
     pyplot.text(data_cutout.shape[1] * 0.6, data_cutout.shape[0] * 0.95,
                 'M2 Pitch: {pitch: 0.3f}"'.format(pitch=header['M2PITCH']), color='white')
     pyplot.text(data_cutout.shape[1] * 0.6, data_cutout.shape[0] * 0.915,
                 'M2 Roll: {roll: 0.3f}"'.format(roll=header['M2ROLL']), color='white')
     pyplot.text(data_cutout.shape[1] * 0.6, data_cutout.shape[0] * 0.88,
                 'FOCDMD: {focdmd: 0.3f} mm'.format(focdmd=header['FOCDMD']), color='white')
+    # If using an sbig camera on a 1m, calculate the M1 offset
+    if 'kb' in header['INSTRUME'].lower() and '1m0' in header['TELID'].lower():
+        pyplot.text(data_cutout.shape[1] * 0.03, data_cutout.shape[0] * 0.03,
+                    'M1 Offset (mm): x={x: 0.3f}, y={y: 0.3f}'.format(
+                        x=calculate_donut_offset(best_fit_model.x0_inner,
+                                                 best_fit_model.x0_outer,
+                                                 sbig=True),
+                        y=calculate_donut_offset(best_fit_model.y0_inner,
+                                                 best_fit_model.y0_outer,
+                                                 sbig=True)),
+                    color='white')
     pyplot.tight_layout()
     pyplot.savefig(output_filename)
 

--- a/pupepat/plot.py
+++ b/pupepat/plot.py
@@ -45,8 +45,8 @@ def plot_best_fit_ellipse(output_filename, data_cutout, best_fit_model, header):
                 'Outer: {x: 0.3f}, {y: 0.3f}'.format(x=best_fit_model.x0_outer, y=best_fit_model.y0_outer),
                 color='white')
 
-    # If using an sbig camera, calculate the M1 offset, otherwise give offset in pixels
-    if 'kb' in header['INSTRUME'].lower():
+    # If using an sbig camera on a 1m, calculate the M1 offset, otherwise give offset in pixels
+    if 'kb' in header['INSTRUME'].lower() and '1m0' in header['TELID'].lower():
         pyplot.text(data_cutout.shape[1] * 0.01, data_cutout.shape[0] * 0.88,
                     'M1 Offset (mm): {x: 0.3f}, {y: 0.3f}'.format(x=calculate_donut_offset(best_fit_model.x0_inner,
                                                                                            best_fit_model.x0_outer,

--- a/pupepat/plot.py
+++ b/pupepat/plot.py
@@ -12,7 +12,7 @@ February 2018
 import matplotlib
 matplotlib.use('Agg')
 from matplotlib import pyplot
-from pupepat.ellipse import generate_ellipse
+from pupepat.ellipse import generate_ellipse, calculate_donut_offset
 import numpy as np
 import os
 
@@ -39,9 +39,29 @@ def plot_best_fit_ellipse(output_filename, data_cutout, best_fit_model, header):
     pyplot.plot(x_outer, y_outer, color='cyan')
     pyplot.title(os.path.basename(os.path.splitext(output_filename)[0]))
     pyplot.text(data_cutout.shape[1] * 0.01, data_cutout.shape[0] * 0.95,
-                'Inner: {x: 0.3f}, {y: 0.3f}'.format(x=best_fit_model.x0_inner, y=best_fit_model.y0_inner), color='white')
+                'Inner: {x: 0.3f}, {y: 0.3f}'.format(x=best_fit_model.x0_inner, y=best_fit_model.y0_inner),
+                color='white')
     pyplot.text(data_cutout.shape[1] * 0.01, data_cutout.shape[0] * 0.915,
-                'Outer: {x: 0.3f}, {y: 0.3f}'.format(x=best_fit_model.x0_outer, y=best_fit_model.y0_outer), color='white')
+                'Outer: {x: 0.3f}, {y: 0.3f}'.format(x=best_fit_model.x0_outer, y=best_fit_model.y0_outer),
+                color='white')
+
+    # If using an sbig camera, calculate the M1 offset, otherwise give offset in pixels
+    if 'kb' in header['INSTRUME'].lower():
+        pyplot.text(data_cutout.shape[1] * 0.01, data_cutout.shape[0] * 0.88,
+                    'M1 Offset (mm): {x: 0.3f}, {y: 0.3f}'.format(x=calculate_donut_offset(best_fit_model.x0_inner,
+                                                                                           best_fit_model.x0_outer,
+                                                                                           sbig=True),
+                                                                  y=calculate_donut_offset(best_fit_model.y0_inner,
+                                                                                           best_fit_model.y0_outer,
+                                                                                           sbig=True)),
+                    color='white')
+    else:
+        pyplot.text(data_cutout.shape[1] * 0.01, data_cutout.shape[0] * 0.88,
+                    'I-O Offset (pix): {x: 0.3f}, {y: 0.3f}'.format(x=calculate_donut_offset(best_fit_model.x0_inner,
+                                                                                             best_fit_model.x0_outer),
+                                                                    y=calculate_donut_offset(best_fit_model.y0_inner,
+                                                                                             best_fit_model.y0_outer)),
+                    color='white')
     pyplot.text(data_cutout.shape[1] * 0.6, data_cutout.shape[0] * 0.95,
                 'M2 Pitch: {pitch: 0.3f}"'.format(pitch=header['M2PITCH']), color='white')
     pyplot.text(data_cutout.shape[1] * 0.6, data_cutout.shape[0] * 0.915,


### PR DESCRIPTION
This change adds an M1 offset to the donut plot if the image is from an sbig on a 1m, and a pixel offset otherwise. 

the M1 offset was [calculated by patrick](https://lcogt.slack.com/archives/C8V95PF9T/p1519653167000491) in Feb. 2018 using zemax. 